### PR TITLE
Update word definitions

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -1,7 +1,9 @@
+puts "Starting up..."
 require_relative 'dictionary'
 require_relative 'controller'
 require_relative 'router'
 
+puts "Loading dictionary..."
 dictionary = Dictionary.new
 controller = Controller.new(dictionary)
 router = Router.new(controller)

--- a/lib/controller.rb
+++ b/lib/controller.rb
@@ -1,6 +1,5 @@
 require 'json'
 require 'rest-client'
-#require 'pry-byebug'
 require_relative 'view'
 require_relative 'word'
 
@@ -55,7 +54,9 @@ class Controller
     # Request new definition
     new_definition = @view.request_input("Please enter the new definition.")
     # Update the dictionary
-    @dictionary.update({'word' => word, 'definition' => definition})
+    @dictionary.update({'word' => word, 'definition' => new_definition})
+    # Confirm to that the definition had been updated
+    @view.confirm_definition_updated(word, new_definition)
   end
 
   private

--- a/lib/dictionary.rb
+++ b/lib/dictionary.rb
@@ -1,4 +1,5 @@
 require 'json'
+#require 'pry-byebug'
 
 class Dictionary
   def initialize

--- a/lib/view.rb
+++ b/lib/view.rb
@@ -39,6 +39,13 @@ class View
     end
   end
 
+  def confirm_definition_updated(word, definition)
+    puts ""
+    puts "Definition updated!"
+    puts "Word: #{word.capitalize}"
+    puts "Definition: #{definition.capitalize}"
+  end
+
   def display_time_taken(word, time_taken)
     puts ""
     puts "#{word} - #{time_taken}"


### PR DESCRIPTION
**Issue:** User-inputted definitions are not updating in the dictionary

**Fix:** The old definition was being passed to the dictionary, rather than the new definition.

Also added "Starting up..." and "Loading dictionary..." for when the application initially initialises, in order to provide some user feedback.